### PR TITLE
Update `actions/checkout` from `v3` to `v4`

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: JohnnyMorganz/stylua-action@v3
       with:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: setup 
       run: |
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: leafo/gh-actions-lua@v9
       with:


### PR DESCRIPTION
This PR updates the used version of [actions/checkout](https://github.com/actions/checkout) from `v3` to `v4` (currently the newest one).