### PR TITLE
Update `leafo/gh-actions-lua` from `v9` to `v10`

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: leafo/gh-actions-lua@v9
+    - uses: leafo/gh-actions-lua@v10
       with:
         luaVersion: "5.1"
 


### PR DESCRIPTION
This PR updates the used version of [`leafo/gh-actions-lua`](https://github.com/leafo/gh-actions-lua) from `v9` to `v10` (currently the newest one).

Similar to #9.