### PR TITLE
Cleanup `code_checks.yml`

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -1,3 +1,4 @@
+---
 name: code_checks
 
 on: [push, pull_request]
@@ -8,44 +9,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: JohnnyMorganz/stylua-action@v3
-      with:
-        version: 0.18.2
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --check .
+      - uses: JohnnyMorganz/stylua-action@v3
+        with:
+          version: 0.18.2
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --check .
 
   lint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: setup 
-      run: |
-        sudo apt install luarocks -qyy
-        sudo luarocks install luacheck
-    - name: lint
-      run: |
-        luacheck .
+      - name: setup
+        run: |
+          sudo apt install luarocks -qyy
+          sudo luarocks install luacheck
+      - name: lint
+        run: |
+          luacheck .
 
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: leafo/gh-actions-lua@v10
-      with:
-        luaVersion: "5.1"
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
 
-    - uses: leafo/gh-actions-luarocks@v4
+      - uses: leafo/gh-actions-luarocks@v4
 
-    - name: setup 
-      run: |
-        luarocks install busted
+      - name: setup
+        run: |
+          luarocks install busted
 
-    - name: test
-      run: |
-        busted -o utfTerminal .spec
+      - name: test
+        run: |
+          busted -o utfTerminal .spec
+...

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -23,13 +23,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+
+      - uses: leafo/gh-actions-luarocks@v4
+
       - name: setup
         run: |
-          sudo apt install luarocks -qyy
-          sudo luarocks install luacheck
+          luarocks install luacheck
+
       - name: lint
         run: |
-          luacheck .
+          luacheck .spec src
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR consists of:

- ecafd0d673cbbd891bb81eff9b41266e7b696533 - basic _cleanup_/_linting_ i.e. removing trailing spaces, fixing indentation etc.,
- dda879c798871361a717ea1fd0e45cceacfd2250 - I am not entirely happy with the outcome. My goal was to unify the `setup` step in [`lint`](https://github.com/TheAlgorithms/Lua/blob/713633272753b77d7e7a32c35676ff94c19f17ad/.github/workflows/code_checks.yml#L19) and [`test`](https://github.com/TheAlgorithms/Lua/blob/713633272753b77d7e7a32c35676ff94c19f17ad/.github/workflows/code_checks.yml#L33) jobs and to use [`leafo/gh-actions-luarocks`](https://github.com/leafo/gh-actions-luarocks) in both of them (such approach is more _cross platform_). It turned out, that [`leafo/gh-actions-lua`](https://github.com/leafo/gh-actions-lua) installs `Lua` in the _working directory_ and as a result, the command `luacheck .` fails (since it is also checking `.lua/` directory). I will not have problems with reverting this commit.