### PR TITLE
Format `.spec`

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           version: 0.18.2
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --check .
+          args: --check .spec src
 
   lint:
     runs-on: ubuntu-latest

--- a/.spec/math/complex_spec.lua
+++ b/.spec/math/complex_spec.lua
@@ -43,9 +43,9 @@ describe("Complex number", function()
 			end
 			for _ = 1, 1e3 do
 				local z = complex.new(math.random(-100, 100), math.random(-100, 100))
-				local perfect_square = z^2
-				assert_equals_ignore_sign(perfect_square, (perfect_square^.5)^2)
-				assert_equals_ignore_sign(perfect_square, (perfect_square:sqrt())^2)
+				local perfect_square = z ^ 2
+				assert_equals_ignore_sign(perfect_square, (perfect_square ^ 0.5) ^ 2)
+				assert_equals_ignore_sign(perfect_square, (perfect_square:sqrt()) ^ 2)
 			end
 		end)
 		it("conjugation works", function()

--- a/.spec/math/intpow_spec.lua
+++ b/.spec/math/intpow_spec.lua
@@ -3,15 +3,15 @@ describe("Integer exponentiation", function()
 	it("should work for small numbers & exponents", function()
 		for n = -1000, 1000 do
 			for exp = -2, 5 do
-				assert.equal(n^exp, intpow(n, exp))
+				assert.equal(n ^ exp, intpow(n, exp))
 			end
 		end
 	end)
 	it("should work for large exponents", function()
 		-- Powers of two don't suffer from float precision issues
 		for i = 1, 100 do
-			assert.equal(2^i * intpow(2, -i), 1)
-			assert.equal(2^-i * intpow(2, i), 1)
+			assert.equal(2 ^ i * intpow(2, -i), 1)
+			assert.equal(2 ^ -i * intpow(2, i), 1)
 		end
 	end)
 end)

--- a/.spec/math/simplist_radical_form_spec.lua
+++ b/.spec/math/simplist_radical_form_spec.lua
@@ -1,7 +1,7 @@
 describe("Simplist radical form", function()
 	local srf = require("math.simplist_radical_form")
 	local function test_srf(x, expected_coeff, expected_root_term)
-		assert.same({expected_coeff, expected_root_term}, {srf(x)})
+		assert.same({ expected_coeff, expected_root_term }, { srf(x) })
 	end
 	it("handles edge cases properly", function()
 		test_srf(0, 1, 0)
@@ -9,14 +9,14 @@ describe("Simplist radical form", function()
 	end)
 	it("works for square numbers", function()
 		for n = 1, 1e3 do
-			test_srf(n*n, n, 1)
+			test_srf(n * n, n, 1)
 		end
 	end)
 	it("works for products of primes ppq", function()
-		local primes = {1, 3, 7, 11, 1013, 4903, 7919}
+		local primes = { 1, 3, 7, 11, 1013, 4903, 7919 }
 		for _, p in ipairs(primes) do
 			for _, q in ipairs(primes) do
-				test_srf(p*p*q, p, q)
+				test_srf(p * p * q, p, q)
 			end
 		end
 	end)

--- a/.spec/misc/coin_change_spec.lua
+++ b/.spec/misc/coin_change_spec.lua
@@ -1,14 +1,12 @@
 local coin_change = require("misc.coin_change")
 describe("Coin change", function()
 	it("should find a set of coins with minimal count and correct sum", function()
-		for value, count in
-			pairs({
-				[13] = 3,
-				[33] = 4,
-				[42] = 3,
-				[50] = 1,
-			})
-		do
+		for value, count in pairs({
+			[13] = 3,
+			[33] = 4,
+			[42] = 3,
+			[50] = 1,
+		}) do
 			local coin_values = coin_change(value, { 1, 2, 5, 10, 20, 50 })
 			assert(count, #coin_values)
 			local sum = 0


### PR DESCRIPTION
While preparing #13, I have noticed that during the [`check_format`](https://github.com/TheAlgorithms/Lua/blob/dd60c56def4b8cc95f9f6660fce173c97ecfa819/.github/workflows/code_checks.yml#L8) job, the [`.spec`](https://github.com/TheAlgorithms/Lua/tree/dd60c56def4b8cc95f9f6660fce173c97ecfa819/.spec) is not checked.

This PR:
- fixes the formatting,
- changed the arguments of the `JohnnyMorganz/stylua-action`.