### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows/"
+    schedule:
+      interval: "daily"
+...


### PR DESCRIPTION
This PR configures dependabot. I added the `"docker"` to handle the updates of [`.gitpod.dockerfile`](https://github.com/TheAlgorithms/Lua/blob/1a620eda7f3a097dea30689b0b007910b3f27198/.gitpod.dockerfile).